### PR TITLE
feat: rename `base_url` parameter to `api_base_url`

### DIFF
--- a/examples/fastapi_server.py
+++ b/examples/fastapi_server.py
@@ -57,7 +57,9 @@ def create_app(
     async def root() -> HTMLResponse:
         """Serves the main UI application with injected environment variables."""
         try:
-            html_content = get_agent_ui_html(api_base_url=api_base_url, ui_config=ui_config)
+            html_content = get_agent_ui_html(
+                api_base_url=api_base_url, ui_config=ui_config
+            )
             return HTMLResponse(content=html_content)
         except FileNotFoundError as e:
             handle_missing_assets(e, "api")

--- a/examples/fastapi_server.py
+++ b/examples/fastapi_server.py
@@ -39,12 +39,12 @@ def handle_missing_assets(e: FileNotFoundError, context: str = "api") -> None:
 
 
 def create_app(
-    base_url: str = "", ui_config: Optional[Dict[str, Any]] = None
+    api_base_url: str = "", ui_config: Optional[Dict[str, Any]] = None
 ) -> FastAPI:
     """Creates FastAPI app with static asset routing.
 
     Args:
-        base_url: Agent API base URL for environment injection
+        api_base_url: Agent API base URL for environment injection
         ui_config: UI configuration object for environment injection
     """
     app = FastAPI(
@@ -57,7 +57,7 @@ def create_app(
     async def root() -> HTMLResponse:
         """Serves the main UI application with injected environment variables."""
         try:
-            html_content = get_agent_ui_html(base_url=base_url, ui_config=ui_config)
+            html_content = get_agent_ui_html(api_base_url=api_base_url, ui_config=ui_config)
             return HTMLResponse(content=html_content)
         except FileNotFoundError as e:
             handle_missing_assets(e, "api")
@@ -92,9 +92,9 @@ def main() -> None:
         print("Warning: Static routes will be unavailable")
 
     # Get base URL from environment variable or use default
-    base_url = os.getenv("AGENT_BASE_URL", "http://localhost:8000/api")
+    api_base_url = os.getenv("AGENT_BASE_URL", "http://localhost:8000/api")
 
-    print(f"Agent Base URL: {base_url}")
+    print(f"Agent Base URL: {api_base_url}")
 
     # Omni Agent UI configuration
     ui_config = {
@@ -135,7 +135,7 @@ def main() -> None:
         "layout": {"enableLayoutSwitchButton": True},
     }
 
-    app = create_app(base_url=base_url, ui_config=ui_config)
+    app = create_app(api_base_url=api_base_url, ui_config=ui_config)
 
     uvicorn.run(app, host="0.0.0.0", port=8000, reload=False, log_level="info")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ tarko_agent_ui = ["static/**/*"]
 
 
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",
     "black>=22.0.0",
@@ -58,7 +58,7 @@ dev-dependencies = [
 ]
 
 [tool.pytest.ini_options]
-minversion = "0.3.4"
+minversion = "7.0"
 addopts = ["-ra", "--cov=tarko_agent_ui"]
 testpaths = ["tests"]
 
@@ -78,7 +78,7 @@ exclude = '''
 '''
 
 [tool.mypy]
-python_version = "0.3.4"
+python_version = "3.9"
 warn_return_any = true
 warn_unused_configs = true
 check_untyped_defs = true

--- a/scripts/auto_release.py
+++ b/scripts/auto_release.py
@@ -14,25 +14,27 @@ import requests
 def run_cmd(cmd, check=True):
     """Run command and optionally check return code."""
     print("🔧 {}".format(cmd))
-    
+
     # Use Popen for compatibility
-    process = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    process = subprocess.Popen(
+        cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
     stdout, stderr = process.communicate()
-    
+
     # Convert bytes to string for Python 2/3 compatibility
-    if hasattr(stdout, 'decode'):
-        stdout = stdout.decode('utf-8')
-        stderr = stderr.decode('utf-8')
-    
+    if hasattr(stdout, "decode"):
+        stdout = stdout.decode("utf-8")
+        stderr = stderr.decode("utf-8")
+
     # Create a simple result object
     class Result:
         def __init__(self, returncode, stdout, stderr):
             self.returncode = returncode
             self.stdout = stdout
             self.stderr = stderr
-    
+
     result = Result(process.returncode, stdout, stderr)
-    
+
     if check and result.returncode != 0:
         print("❌ Command failed: {}".format(cmd))
         print("stdout: {}".format(result.stdout))
@@ -51,7 +53,9 @@ def get_npm_latest_version():
     """Get latest npm version from registry."""
     print("🔍 Fetching latest npm version...")
     try:
-        response = requests.get("https://registry.npmjs.org/@tarko/agent-ui-builder/latest", timeout=10)
+        response = requests.get(
+            "https://registry.npmjs.org/@tarko/agent-ui-builder/latest", timeout=10
+        )
         response.raise_for_status()
         version = response.json()["version"]
         print("📦 Latest npm version: {}".format(version))
@@ -74,7 +78,7 @@ def get_current_python_version():
 
 def bump_patch_version(version):
     """Bump patch version: 0.3.0 -> 0.3.1"""
-    match = re.match(r'^(\d+)\.(\d+)\.(\d+)', version)
+    match = re.match(r"^(\d+)\.(\d+)\.(\d+)", version)
     if not match:
         raise ValueError("Invalid version format: {}".format(version))
     major, minor, patch = match.groups()
@@ -83,71 +87,93 @@ def bump_patch_version(version):
 
 def ensure_versions_consistent(python_version, npm_version):
     """Ensure Python and npm versions are consistent (same major.minor)."""
-    py_match = re.match(r'^(\d+)\.(\d+)', python_version)
-    npm_match = re.match(r'^(\d+)\.(\d+)', npm_version)
-    
+    py_match = re.match(r"^(\d+)\.(\d+)", python_version)
+    npm_match = re.match(r"^(\d+)\.(\d+)", npm_version)
+
     if not py_match or not npm_match:
-        raise ValueError("Invalid version format: Python={}, npm={}".format(python_version, npm_version))
-    
+        raise ValueError(
+            "Invalid version format: Python={}, npm={}".format(
+                python_version, npm_version
+            )
+        )
+
     py_major_minor = "{}.{}".format(py_match.group(1), py_match.group(2))
     npm_major_minor = "{}.{}".format(npm_match.group(1), npm_match.group(2))
-    
+
     if py_major_minor != npm_major_minor:
         print("⚠️  Version mismatch detected:")
         print("   Python: {} (major.minor: {})".format(python_version, py_major_minor))
         print("   npm: {} (major.minor: {})".format(npm_version, npm_major_minor))
-        print("\n💡 Python and npm packages should have consistent major.minor versions")
-        
+        print(
+            "\n💡 Python and npm packages should have consistent major.minor versions"
+        )
+
         if input("❓ Continue anyway? [y/N]: ").lower() != "y":
             print("❌ Release cancelled due to version mismatch")
             sys.exit(1)
     else:
-        print("✅ Version consistency check passed (major.minor: {})".format(py_major_minor))
+        print(
+            "✅ Version consistency check passed (major.minor: {})".format(
+                py_major_minor
+            )
+        )
 
 
 def update_version_files(python_version, npm_version):
     """Update version in pyproject.toml and __init__.py."""
-    print("📝 Updating version files: Python {}, npm {}".format(python_version, npm_version))
-    
+    print(
+        "📝 Updating version files: Python {}, npm {}".format(
+            python_version, npm_version
+        )
+    )
+
     # Update pyproject.toml
     with open("pyproject.toml", "r") as f:
         content = f.read()
-    content = re.sub(r'version = "[^"]+"', 'version = "{}"'.format(python_version), content)
+    content = re.sub(
+        r'version = "[^"]+"', 'version = "{}"'.format(python_version), content
+    )
     with open("pyproject.toml", "w") as f:
         f.write(content)
-    
+
     # Update __init__.py
     with open("tarko_agent_ui/__init__.py", "r") as f:
         content = f.read()
-    content = re.sub(r'__version__ = "[^"]+"', '__version__ = "{}"'.format(python_version), content)
-    content = re.sub(r'__npm_version__ = "[^"]+"', '__npm_version__ = "{}"'.format(npm_version), content)
+    content = re.sub(
+        r'__version__ = "[^"]+"', '__version__ = "{}"'.format(python_version), content
+    )
+    content = re.sub(
+        r'__npm_version__ = "[^"]+"',
+        '__npm_version__ = "{}"'.format(npm_version),
+        content,
+    )
     with open("tarko_agent_ui/__init__.py", "w") as f:
         f.write(content)
-    
+
     print("✅ Version files updated")
 
 
 def clean_old_artifacts():
     """Clean old build artifacts to ensure fresh build."""
     print("🧹 Cleaning old artifacts...")
-    
+
     artifacts_to_clean = [
         "dist",
-        "build", 
+        "build",
         "*.egg-info",
         "tarko_agent_ui/static",
         "tarko_agent_ui/_static_version.py",
         "tarko_agent_ui/__pycache__",
-        ".pytest_cache"
+        ".pytest_cache",
     ]
-    
+
     for artifact in artifacts_to_clean:
         run_cmd("rm -rf {}".format(artifact), check=False)
-    
+
     # Also clean Python cache files
     run_cmd("find . -name '*.pyc' -delete", check=False)
     run_cmd("find . -name '__pycache__' -type d -exec rm -rf {} +", check=False)
-    
+
     print("✅ Old artifacts cleaned")
 
 
@@ -155,14 +181,14 @@ def build_static_assets(npm_version):
     """Build static assets from npm package."""
     print("🏗️  Building static assets with npm version {}...".format(npm_version))
     run_cmd("uv run python scripts/build_assets.py --version='{}'".format(npm_version))
-    
+
     # Verify static assets were built
     static_dir = "tarko_agent_ui/static"
     index_file = os.path.join(static_dir, "index.html")
-    
+
     if not os.path.exists(static_dir) or not os.path.exists(index_file):
         raise RuntimeError("Static assets build failed - missing files")
-    
+
     print("✅ Static assets built successfully")
 
 
@@ -176,21 +202,21 @@ def run_tests():
 def build_and_verify_package():
     """Build Python package and verify it can be published."""
     print("📦 Building Python package...")
-    
+
     # Create dist directory
     run_cmd("mkdir -p dist")
-    
+
     # Build package
     run_cmd("uv build")
-    
+
     # Verify dist files exist
     if not os.path.exists("dist"):
         raise RuntimeError("Package build failed - dist directory not found")
-    
+
     dist_files = os.listdir("dist")
     if not dist_files:
         raise RuntimeError("Package build failed - no files in dist/")
-    
+
     print("✅ Package built successfully: {}".format(dist_files))
 
 
@@ -198,14 +224,14 @@ def create_release_branch(version):
     """Create and switch to release branch."""
     branch_name = "release/{}".format(version)
     print("🌿 Creating release branch: {}".format(branch_name))
-    
+
     # Ensure we're on main and up to date
     run_cmd("git checkout main")
     run_cmd("git pull origin main")
-    
+
     # Create and switch to release branch
     run_cmd("git checkout -b {}".format(branch_name))
-    
+
     print("✅ Created and switched to branch: {}".format(branch_name))
     return branch_name
 
@@ -213,16 +239,16 @@ def create_release_branch(version):
 def commit_and_tag(version):
     """Commit changes and create git tag."""
     print("📝 Committing release v{}...".format(version))
-    
+
     # Add all changes
     run_cmd("git add .")
-    
+
     # Commit with conventional commit format
     run_cmd('git commit -m "release: v{}"'.format(version))
-    
+
     # Create tag
     run_cmd("git tag v{}".format(version))
-    
+
     print("✅ Committed and tagged v{}".format(version))
 
 
@@ -230,13 +256,13 @@ def push_release(version):
     """Push release branch and tags to remote."""
     branch_name = "release/{}".format(version)
     print("🚀 Pushing {} and tags...".format(branch_name))
-    
+
     # Push branch
     run_cmd("git push origin {}".format(branch_name))
-    
+
     # Push tags
     run_cmd("git push origin --tags")
-    
+
     print("✅ Pushed {} and tags to remote".format(branch_name))
 
 
@@ -257,89 +283,105 @@ def publish_package():
 def main():
     """Main release workflow."""
     import argparse
-    
-    parser = argparse.ArgumentParser(description="Optimized Python package release script")
+
+    parser = argparse.ArgumentParser(
+        description="Optimized Python package release script"
+    )
     parser.add_argument("--npm-version", help="Specific npm version (default: latest)")
-    parser.add_argument("--dry-run", action="store_true", help="Show what would be done")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Show what would be done"
+    )
     parser.add_argument("--skip-tests", action="store_true", help="Skip running tests")
-    parser.add_argument("--skip-publish", action="store_true", help="Skip publishing to PyPI")
-    
+    parser.add_argument(
+        "--skip-publish", action="store_true", help="Skip publishing to PyPI"
+    )
+
     args = parser.parse_args()
-    
+
     try:
         # 1. Get current state
         original_branch = get_current_branch()
         print("🎯 Starting release from branch: {}".format(original_branch))
-        
+
         # 2. Determine versions
         npm_version = args.npm_version or get_npm_latest_version()
         current_python_version = get_current_python_version()
         new_python_version = bump_patch_version(current_python_version)
-        
+
         # 3. Check version consistency
         ensure_versions_consistent(new_python_version, npm_version)
-        
+
         print("\n📋 Release Plan:")
         print("   📦 npm version: {}".format(npm_version))
-        print("   🐍 Python: {} -> {}".format(current_python_version, new_python_version))
+        print(
+            "   🐍 Python: {} -> {}".format(current_python_version, new_python_version)
+        )
         print("   🌿 Release branch: release/{}".format(new_python_version))
         print("   🔗 Version consistency: ✅")
-        
+
         if args.dry_run:
             print("\n🔍 DRY RUN - No changes will be made")
             return
-        
+
         # 3. Confirm release
         if input("\n❓ Proceed with release? [y/N]: ").lower() != "y":
             print("❌ Release cancelled")
             return
-        
+
         print("\n🚀 Starting release process...")
-        
+
         # 4. Create release branch
         create_release_branch(new_python_version)
-        
+
         try:
             # 5. Clean old artifacts
             clean_old_artifacts()
-            
+
             # 6. Update version files
             update_version_files(new_python_version, npm_version)
-            
+
             # 7. Build static assets
             build_static_assets(npm_version)
-            
+
             # 8. Run tests (unless skipped)
             if not args.skip_tests:
                 run_tests()
-            
+
             # 9. Build package
             build_and_verify_package()
-            
+
             # 10. Commit and tag
             commit_and_tag(new_python_version)
-            
+
             # 11. Push to remote
             push_release(new_python_version)
-            
+
             # 12. Publish package (unless skipped)
             if not args.skip_publish:
                 publish_package()
-                
+
                 # 13. Show testing instructions
                 print("\n🧪 Testing Instructions:")
-                print("   Run: python scripts/test_release.py --version {}".format(new_python_version))
-                print("   Or quick test: python scripts/test_release.py --version {} --quick".format(new_python_version))
-            
+                print(
+                    "   Run: python scripts/test_release.py --version {}".format(
+                        new_python_version
+                    )
+                )
+                print(
+                    "   Or quick test: python scripts/test_release.py --version {} --quick".format(
+                        new_python_version
+                    )
+                )
+
             print("\n🎉 Successfully released v{}!".format(new_python_version))
             print("📦 npm version: {}".format(npm_version))
             print("🐍 Python version: {}".format(new_python_version))
             print("🌿 Release branch: release/{}".format(new_python_version))
-            
+
         finally:
             # 14. Always switch back to original branch
             switch_back_to_original_branch(original_branch)
-            
+
     except KeyboardInterrupt:
         print("\n❌ Release interrupted by user")
         sys.exit(1)

--- a/scripts/auto_release.py
+++ b/scripts/auto_release.py
@@ -23,8 +23,11 @@ def run_cmd(cmd, check=True):
 
     # Convert bytes to string for Python 2/3 compatibility
     if hasattr(stdout, "decode"):
-        stdout = stdout.decode("utf-8")
-        stderr = stderr.decode("utf-8")
+        stdout_str: str = stdout.decode("utf-8")  # type: ignore
+        stderr_str: str = stderr.decode("utf-8")  # type: ignore
+    else:
+        stdout_str = str(stdout)
+        stderr_str = str(stderr)
 
     # Create a simple result object
     class Result:
@@ -33,7 +36,7 @@ def run_cmd(cmd, check=True):
             self.stdout = stdout
             self.stderr = stderr
 
-    result = Result(process.returncode, stdout, stderr)
+    result = Result(process.returncode, stdout_str, stderr_str)
 
     if check and result.returncode != 0:
         print("❌ Command failed: {}".format(cmd))

--- a/scripts/validate_scripts.py
+++ b/scripts/validate_scripts.py
@@ -15,31 +15,33 @@ import os
 def run_cmd(cmd, check=True):
     """Run command with proper error handling."""
     print("🔧 {}".format(cmd))
-    
+
     # Use Popen for compatibility with older Python versions
-    process = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    process = subprocess.Popen(
+        cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
     stdout, stderr = process.communicate()
-    
+
     # Convert bytes to string for Python 2/3 compatibility
-    if hasattr(stdout, 'decode'):
-        stdout = stdout.decode('utf-8')
-        stderr = stderr.decode('utf-8')
-    
+    if hasattr(stdout, "decode"):
+        stdout = stdout.decode("utf-8")
+        stderr = stderr.decode("utf-8")
+
     # Create a simple result object
     class Result:
         def __init__(self, returncode, stdout, stderr):
             self.returncode = returncode
             self.stdout = stdout
             self.stderr = stderr
-    
+
     result = Result(process.returncode, stdout, stderr)
-    
+
     if check and result.returncode != 0:
         print("❌ Command failed: {}".format(cmd))
         print("stdout: {}".format(result.stdout))
         print("stderr: {}".format(result.stderr))
         return result
-    
+
     return result
 
 
@@ -48,11 +50,11 @@ def check_file_exists(filepath):
     if not os.path.exists(filepath):
         print("❌ File not found: {}".format(filepath))
         return False
-    
+
     if not os.path.isfile(filepath):
         print("❌ Not a file: {}".format(filepath))
         return False
-    
+
     print("✅ File exists: {}".format(filepath))
     return True
 
@@ -61,7 +63,7 @@ def check_script_syntax(script_path):
     """Check if Python script has valid syntax."""
     print("🧪 Checking syntax: {}".format(script_path))
     result = run_cmd("python -m py_compile {}".format(script_path), check=False)
-    
+
     if result.returncode == 0:
         print("✅ Syntax OK: {}".format(script_path))
         return True
@@ -75,7 +77,7 @@ def check_script_help(script_path):
     """Check if script can show help without errors."""
     print("🧪 Testing help: {}".format(script_path))
     result = run_cmd("python {} --help".format(script_path), check=False)
-    
+
     if result.returncode == 0 and "usage:" in result.stdout.lower():
         print("✅ Help works: {}".format(script_path))
         return True
@@ -91,102 +93,112 @@ def check_script_help(script_path):
 def check_dependencies():
     """Check if required dependencies are available."""
     print("🧪 Checking dependencies...")
-    
+
     dependencies = [
         ("python", "python --version"),
         ("git", "git --version"),
         ("uv", "uv --version"),
     ]
-    
+
     all_ok = True
     for name, cmd in dependencies:
         result = run_cmd(cmd, check=False)
         if result.returncode == 0:
-            version = result.stdout.strip().split('\n')[0]
+            version = result.stdout.strip().split("\n")[0]
             print("✅ {}: {}".format(name, version))
         else:
             print("❌ {}: not found or not working".format(name))
             all_ok = False
-    
+
     # Check Python packages
     python_packages = ["requests"]
     for package in python_packages:
-        result = run_cmd("python -c 'import {}; print(\"{} imported successfully\")'".format(package, package), check=False)
+        result = run_cmd(
+            "python -c 'import {}; print(\"{} imported successfully\")'".format(
+                package, package
+            ),
+            check=False,
+        )
         if result.returncode == 0:
             print("✅ Python package: {}".format(package))
         else:
             print("❌ Python package missing: {}".format(package))
             all_ok = False
-    
+
     return all_ok
 
 
 def check_project_structure():
     """Check if project has the expected structure."""
     print("🧪 Checking project structure...")
-    
+
     required_files = [
         "pyproject.toml",
         "tarko_agent_ui/__init__.py",
         "scripts/build_assets.py",
-        "examples/fastapi_server.py"
+        "examples/fastapi_server.py",
     ]
-    
+
     all_ok = True
     for filepath in required_files:
         if not check_file_exists(filepath):
             all_ok = False
-    
+
     return all_ok
 
 
 def check_version_consistency():
     """Check if version info can be read correctly."""
     print("🧪 Checking version consistency...")
-    
+
     try:
         # Check pyproject.toml version
         with open("pyproject.toml", "r") as f:
             pyproject_content = f.read()
-        
+
         import re
+
         version_match = re.search(r'version = "([^"]+)"', pyproject_content)
         if not version_match:
             print("❌ Could not find version in pyproject.toml")
             return False
-        
+
         pyproject_version = version_match.group(1)
         print("✅ pyproject.toml version: {}".format(pyproject_version))
-        
+
         # Check __init__.py version
         with open("tarko_agent_ui/__init__.py", "r") as f:
             init_content = f.read()
-        
+
         version_match = re.search(r'__version__ = "([^"]+)"', init_content)
         if not version_match:
             print("❌ Could not find __version__ in __init__.py")
             return False
-        
+
         init_version = version_match.group(1)
         print("✅ __init__.py version: {}".format(init_version))
-        
+
         # Check npm version
         npm_match = re.search(r'__npm_version__ = "([^"]+)"', init_content)
         if not npm_match:
             print("❌ Could not find __npm_version__ in __init__.py")
             return False
-        
+
         npm_version = npm_match.group(1)
         print("✅ npm version: {}".format(npm_version))
-        
+
         # Check version consistency
         if pyproject_version != init_version:
-            print("⚠️  Version mismatch: pyproject.toml={}, __init__.py={}".format(pyproject_version, init_version))
+            print(
+                "⚠️  Version mismatch: pyproject.toml={}, __init__.py={}".format(
+                    pyproject_version, init_version
+                )
+            )
             return False
-        
+
         print("✅ Version consistency check passed")
         return True
-        
+
     except Exception as e:
         print("❌ Version check failed: {}".format(e))
         return False
@@ -195,10 +207,13 @@ def check_version_consistency():
 def test_dry_run():
     """Test auto_release.py in dry-run mode."""
     print("🧪 Testing auto_release.py dry-run...")
-    
+
     # This should not make any changes
-    result = run_cmd("python scripts/auto_release.py --dry-run --npm-version '0.3.0-beta.12'", check=False)
-    
+    result = run_cmd(
+        "python scripts/auto_release.py --dry-run --npm-version '0.3.0-beta.12'",
+        check=False,
+    )
+
     if result.returncode == 0:
         if "DRY RUN" in result.stdout and "No changes will be made" in result.stdout:
             print("✅ Dry-run test passed")
@@ -216,26 +231,32 @@ def test_dry_run():
 def main():
     """Run all validation checks."""
     print("🚀 Validating release scripts...\n")
-    
+
     checks = [
         ("Project Structure", check_project_structure),
         ("Dependencies", check_dependencies),
         ("Version Consistency", check_version_consistency),
-        ("auto_release.py Syntax", lambda: check_script_syntax("scripts/auto_release.py")),
-        ("test_release.py Syntax", lambda: check_script_syntax("scripts/test_release.py")),
+        (
+            "auto_release.py Syntax",
+            lambda: check_script_syntax("scripts/auto_release.py"),
+        ),
+        (
+            "test_release.py Syntax",
+            lambda: check_script_syntax("scripts/test_release.py"),
+        ),
         ("auto_release.py Help", lambda: check_script_help("scripts/auto_release.py")),
         ("test_release.py Help", lambda: check_script_help("scripts/test_release.py")),
         ("Dry-run Test", test_dry_run),
     ]
-    
+
     passed = 0
     total = len(checks)
-    
+
     for name, check_func in checks:
-        print("\n" + "="*50)
+        print("\n" + "=" * 50)
         print("📋 {}".format(name))
-        print("="*50)
-        
+        print("=" * 50)
+
         try:
             if check_func():
                 passed += 1
@@ -244,12 +265,12 @@ def main():
                 print("❌ {}: FAILED".format(name))
         except Exception as e:
             print("❌ {}: ERROR - {}".format(name, e))
-    
-    print("\n" + "="*50)
+
+    print("\n" + "=" * 50)
     print("📊 VALIDATION RESULTS")
-    print('='*50)
+    print("=" * 50)
     print("Passed: {}/{}".format(passed, total))
-    
+
     if passed == total:
         print("\n🎉 All validation checks passed!")
         print("✅ Release scripts are ready to use.")

--- a/scripts/validate_scripts.py
+++ b/scripts/validate_scripts.py
@@ -24,8 +24,11 @@ def run_cmd(cmd, check=True):
 
     # Convert bytes to string for Python 2/3 compatibility
     if hasattr(stdout, "decode"):
-        stdout = stdout.decode("utf-8")
-        stderr = stderr.decode("utf-8")
+        stdout_str: str = stdout.decode("utf-8")  # type: ignore
+        stderr_str: str = stderr.decode("utf-8")  # type: ignore
+    else:
+        stdout_str = str(stdout)
+        stderr_str = str(stderr)
 
     # Create a simple result object
     class Result:
@@ -34,7 +37,7 @@ def run_cmd(cmd, check=True):
             self.stdout = stdout
             self.stderr = stderr
 
-    result = Result(process.returncode, stdout, stderr)
+    result = Result(process.returncode, stdout_str, stderr_str)
 
     if check and result.returncode != 0:
         print("❌ Command failed: {}".format(cmd))

--- a/tarko_agent_ui/__init__.py
+++ b/tarko_agent_ui/__init__.py
@@ -58,13 +58,13 @@ def get_static_version() -> dict:
 
 
 def inject_env_variables(
-    html_content: str, base_url: str = "", ui_config: Optional[Dict[str, Any]] = None
+    html_content: str, api_base_url: str = "", ui_config: Optional[Dict[str, Any]] = None
 ) -> str:
     """Injects environment variables into HTML head section.
 
     Args:
         html_content: The HTML content to modify
-        base_url: Agent API base URL (defaults to empty string)
+        api_base_url: Agent API base URL (defaults to empty string)
         ui_config: UI configuration object (defaults to empty dict)
 
     Returns:
@@ -77,7 +77,7 @@ def inject_env_variables(
         ui_config = {}
 
     script_tag = f"""<script>
-      window.AGENT_BASE_URL = {json.dumps(base_url)};
+      window.AGENT_BASE_URL = {json.dumps(api_base_url)};
       window.AGENT_WEB_UI_CONFIG = {json.dumps(ui_config)};
       console.log("Agent: Using API baseURL:", window.AGENT_BASE_URL);
     </script>"""
@@ -102,12 +102,12 @@ def inject_env_variables(
 
 
 def get_agent_ui_html(
-    base_url: str = "", ui_config: Optional[Dict[str, Any]] = None
+    api_base_url: str = "", ui_config: Optional[Dict[str, Any]] = None
 ) -> str:
     """Returns configured Agent UI HTML content.
 
     Args:
-        base_url: Agent API base URL (defaults to empty string)
+        api_base_url: Agent API base URL (defaults to empty string)
         ui_config: UI configuration object (defaults to empty dict)
 
     Returns:
@@ -125,5 +125,5 @@ def get_agent_ui_html(
 
     html_content = index_file.read_text(encoding="utf-8")
     return inject_env_variables(
-        html_content=html_content, base_url=base_url, ui_config=ui_config
+        html_content=html_content, api_base_url=api_base_url, ui_config=ui_config
     )

--- a/tarko_agent_ui/__init__.py
+++ b/tarko_agent_ui/__init__.py
@@ -58,7 +58,9 @@ def get_static_version() -> dict:
 
 
 def inject_env_variables(
-    html_content: str, api_base_url: str = "", ui_config: Optional[Dict[str, Any]] = None
+    html_content: str,
+    api_base_url: str = "",
+    ui_config: Optional[Dict[str, Any]] = None,
 ) -> str:
     """Injects environment variables into HTML head section.
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -60,7 +60,7 @@ class TestInjectEnvVariables:
     def test_inject_basic_variables(self):
         """Test basic environment variable injection."""
         html = "<html><head></head><body></body></html>"
-        result = inject_env_variables(html, "http://api.example.com")
+        result = inject_env_variables(html, api_base_url="http://api.example.com")
 
         assert 'window.AGENT_BASE_URL = "http://api.example.com"' in result
         assert "window.AGENT_WEB_UI_CONFIG = {}" in result
@@ -69,7 +69,7 @@ class TestInjectEnvVariables:
         """Test injection with UI configuration."""
         html = "<html><head></head><body></body></html>"
         ui_config = {"title": "Test Agent"}
-        result = inject_env_variables(html, "http://api.example.com", ui_config)
+        result = inject_env_variables(html, api_base_url="http://api.example.com", ui_config=ui_config)
 
         assert 'window.AGENT_BASE_URL = "http://api.example.com"' in result
         assert '"title": "Test Agent"' in result
@@ -81,7 +81,7 @@ class TestInjectEnvVariables:
         with pytest.raises(
             ValueError, match="HTML content must contain a valid <head> section"
         ):
-            inject_env_variables(html, "http://api.example.com")
+            inject_env_variables(html, api_base_url="http://api.example.com")
 
 
 class TestGetAgentUIHTML:
@@ -100,7 +100,7 @@ class TestGetAgentUIHTML:
             mock_index_file.exists.return_value = True
             mock_index_file.read_text.return_value = mock_html
 
-            result = get_agent_ui_html("http://api.example.com", {"title": "Test"})
+            result = get_agent_ui_html(api_base_url="http://api.example.com", ui_config={"title": "Test"})
 
             assert 'window.AGENT_BASE_URL = "http://api.example.com"' in result
             assert '"title": "Test"' in result

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -69,7 +69,9 @@ class TestInjectEnvVariables:
         """Test injection with UI configuration."""
         html = "<html><head></head><body></body></html>"
         ui_config = {"title": "Test Agent"}
-        result = inject_env_variables(html, api_base_url="http://api.example.com", ui_config=ui_config)
+        result = inject_env_variables(
+            html, api_base_url="http://api.example.com", ui_config=ui_config
+        )
 
         assert 'window.AGENT_BASE_URL = "http://api.example.com"' in result
         assert '"title": "Test Agent"' in result
@@ -100,7 +102,9 @@ class TestGetAgentUIHTML:
             mock_index_file.exists.return_value = True
             mock_index_file.read_text.return_value = mock_html
 
-            result = get_agent_ui_html(api_base_url="http://api.example.com", ui_config={"title": "Test"})
+            result = get_agent_ui_html(
+                api_base_url="http://api.example.com", ui_config={"title": "Test"}
+            )
 
             assert 'window.AGENT_BASE_URL = "http://api.example.com"' in result
             assert '"title": "Test"' in result


### PR DESCRIPTION
## Summary

Rename `base_url` parameter to `api_base_url` across all public APIs for better semantic clarity. The parameter represents the Agent API base URL, so `api_base_url` is more descriptive and aligns with common naming conventions.

**Changes:**
- Updated `inject_env_variables()` function signature
- Updated `get_agent_ui_html()` function signature  
- Updated FastAPI example implementation
- Updated all test cases with new parameter name

## Checklist  

- [x] Added or updated necessary tests (Optional).  
- [ ] Updated documentation to align with changes (Optional).  
- [x] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).  
- [ ] My change does not involve the above items.