### PR TITLE
feat: add webui config parameter with backwards compatibility

### DIFF
--- a/examples/fastapi_server.py
+++ b/examples/fastapi_server.py
@@ -39,13 +39,13 @@ def handle_missing_assets(e: FileNotFoundError, context: str = "api") -> None:
 
 
 def create_app(
-    api_base_url: str = "", ui_config: Optional[Dict[str, Any]] = None
+    api_base_url: str = "", webui: Optional[Dict[str, Any]] = None
 ) -> FastAPI:
     """Creates FastAPI app with static asset routing.
 
     Args:
         api_base_url: Agent API base URL for environment injection
-        ui_config: UI configuration object for environment injection
+        webui: Web UI configuration object for environment injection
     """
     app = FastAPI(
         title="Tarko Agent UI Server",
@@ -58,7 +58,7 @@ def create_app(
         """Serves the main UI application with injected environment variables."""
         try:
             html_content = get_agent_ui_html(
-                api_base_url=api_base_url, ui_config=ui_config
+                api_base_url=api_base_url, webui=webui
             )
             return HTMLResponse(content=html_content)
         except FileNotFoundError as e:
@@ -99,7 +99,7 @@ def main() -> None:
     print(f"Agent Base URL: {api_base_url}")
 
     # Omni Agent UI configuration
-    ui_config = {
+    webui = {
         "logo": "https://lf3-static.bytednsdoc.com/obj/eden-cn/zyha-aulnh/ljhwZthlaukjlkulzlp/icon.png",
         "title": "Omni Agent",
         "subtitle": "Offering seamless integration with a wide range of real-world tools.",
@@ -137,7 +137,7 @@ def main() -> None:
         "layout": {"enableLayoutSwitchButton": True},
     }
 
-    app = create_app(api_base_url=api_base_url, ui_config=ui_config)
+    app = create_app(api_base_url=api_base_url, webui=webui)
 
     uvicorn.run(app, host="0.0.0.0", port=8000, reload=False, log_level="info")
 

--- a/examples/fastapi_server.py
+++ b/examples/fastapi_server.py
@@ -57,9 +57,7 @@ def create_app(
     async def root() -> HTMLResponse:
         """Serves the main UI application with injected environment variables."""
         try:
-            html_content = get_agent_ui_html(
-                api_base_url=api_base_url, webui=webui
-            )
+            html_content = get_agent_ui_html(api_base_url=api_base_url, webui=webui)
             return HTMLResponse(content=html_content)
         except FileNotFoundError as e:
             handle_missing_assets(e, "api")

--- a/tarko_agent_ui/__init__.py
+++ b/tarko_agent_ui/__init__.py
@@ -80,7 +80,7 @@ def inject_env_variables(
     # Handle backwards compatibility with ui_config
     if ui_config is not None and webui is not None:
         raise ValueError("Cannot specify both ui_config and webui. Use webui instead.")
-    
+
     # Use webui if provided, otherwise fall back to ui_config for backwards compatibility
     config = webui if webui is not None else (ui_config or {})
 
@@ -110,7 +110,7 @@ def inject_env_variables(
 
 
 def get_agent_ui_html(
-    api_base_url: str = "", 
+    api_base_url: str = "",
     ui_config: Optional[Dict[str, Any]] = None,
     webui: Optional[Dict[str, Any]] = None,
 ) -> str:
@@ -136,8 +136,8 @@ def get_agent_ui_html(
 
     html_content = index_file.read_text(encoding="utf-8")
     return inject_env_variables(
-        html_content=html_content, 
-        api_base_url=api_base_url, 
+        html_content=html_content,
+        api_base_url=api_base_url,
         ui_config=ui_config,
-        webui=webui
+        webui=webui,
     )

--- a/tarko_agent_ui/__init__.py
+++ b/tarko_agent_ui/__init__.py
@@ -61,13 +61,15 @@ def inject_env_variables(
     html_content: str,
     api_base_url: str = "",
     ui_config: Optional[Dict[str, Any]] = None,
+    webui: Optional[Dict[str, Any]] = None,
 ) -> str:
     """Injects environment variables into HTML head section.
 
     Args:
         html_content: The HTML content to modify
         api_base_url: Agent API base URL (defaults to empty string)
-        ui_config: UI configuration object (defaults to empty dict)
+        ui_config: UI configuration object (defaults to empty dict) - DEPRECATED, use webui instead
+        webui: Web UI configuration object (defaults to empty dict)
 
     Returns:
         Modified HTML content with injected environment variables
@@ -75,12 +77,16 @@ def inject_env_variables(
     Raises:
         ValueError: If HTML content doesn't contain a valid head section
     """
-    if ui_config is None:
-        ui_config = {}
+    # Handle backwards compatibility with ui_config
+    if ui_config is not None and webui is not None:
+        raise ValueError("Cannot specify both ui_config and webui. Use webui instead.")
+    
+    # Use webui if provided, otherwise fall back to ui_config for backwards compatibility
+    config = webui if webui is not None else (ui_config or {})
 
     script_tag = f"""<script>
       window.AGENT_BASE_URL = {json.dumps(api_base_url)};
-      window.AGENT_WEB_UI_CONFIG = {json.dumps(ui_config)};
+      window.AGENT_WEB_UI_CONFIG = {json.dumps(config)};
       console.log("Agent: Using API baseURL:", window.AGENT_BASE_URL);
     </script>"""
 
@@ -104,13 +110,16 @@ def inject_env_variables(
 
 
 def get_agent_ui_html(
-    api_base_url: str = "", ui_config: Optional[Dict[str, Any]] = None
+    api_base_url: str = "", 
+    ui_config: Optional[Dict[str, Any]] = None,
+    webui: Optional[Dict[str, Any]] = None,
 ) -> str:
     """Returns configured Agent UI HTML content.
 
     Args:
         api_base_url: Agent API base URL (defaults to empty string)
-        ui_config: UI configuration object (defaults to empty dict)
+        ui_config: UI configuration object (defaults to empty dict) - DEPRECATED, use webui instead
+        webui: Web UI configuration object (defaults to empty dict)
 
     Returns:
         HTML content with injected environment variables
@@ -127,5 +136,8 @@ def get_agent_ui_html(
 
     html_content = index_file.read_text(encoding="utf-8")
     return inject_env_variables(
-        html_content=html_content, api_base_url=api_base_url, ui_config=ui_config
+        html_content=html_content, 
+        api_base_url=api_base_url, 
+        ui_config=ui_config,
+        webui=webui
     )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -81,12 +81,13 @@ class TestInjectEnvVariables:
         html = "<html><head></head><body></body></html>"
         ui_config = {"title": "Old Config"}
         webui = {"title": "New Config"}
-        
-        with pytest.raises(
-            ValueError, match="Cannot specify both ui_config and webui"
-        ):
+
+        with pytest.raises(ValueError, match="Cannot specify both ui_config and webui"):
             inject_env_variables(
-                html, api_base_url="http://api.example.com", ui_config=ui_config, webui=webui
+                html,
+                api_base_url="http://api.example.com",
+                ui_config=ui_config,
+                webui=webui,
             )
 
     def test_inject_backwards_compatibility(self):


### PR DESCRIPTION
## Summary

Add `webui` configuration parameter to align with Tarko architecture while maintaining backwards compatibility with existing `ui_config` parameter.

- Add `webui` parameter to `inject_env_variables()` and `get_agent_ui_html()` functions
- Mark `ui_config` as DEPRECATED but keep it functional for backwards compatibility  
- Prevent simultaneous use of both parameters with validation
- Update example code to demonstrate new `webui` parameter usage
- Add comprehensive test coverage for new functionality

## Checklist  

- [x] Added or updated necessary tests (Optional).  
- [x] Updated documentation to align with changes (Optional).  
- [x] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).  
- [ ] My change does not involve the above items.